### PR TITLE
Fix custom properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,8 @@ module.exports = postcss.plugin("postcss-spiffing", function (opts) {
           decl.value = decl.value.substring(0, decl.value.length-7).trim();
           decl.important = true;
         }
+
+        decl.value = decl.value.replace(/(var\(--[^\)]*)colour([^\)]*\))/, "$1color$2");
       });
 
       css.eachAtRule(function(rule) {

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = postcss.plugin("postcss-spiffing", function (opts) {
           decl.important = true;
         }
 
-        decl.value = decl.value.replace(/(var\(--[^\)]*)colour([^\)]*\))/, "$1color$2");
+        decl.value = decl.value.replace(/(var\(--[^\)]*)colour([^\)]*\))/g, "$1color$2");
       });
 
       css.eachAtRule(function(rule) {

--- a/test/test.css
+++ b/test/test.css
@@ -1,7 +1,12 @@
 /* Your well-spelt CSS */
 
+:root {
+    --colour-green: #0f0;
+}
+
 body {
   background-colour: grey !please;
+  colour: var(--colour-green);
   transparency: 0.5;
   text-align: centre;
   font-weight: plump;


### PR DESCRIPTION
Only renaming the declarations of custom properties caused them
to be undefined. Now, references to custom properties via var() are
also renamed.
